### PR TITLE
Add build-essential, bump chef version

### DIFF
--- a/strongloop.yaml
+++ b/strongloop.yaml
@@ -71,7 +71,7 @@ parameters:
   chef_version:
     description: Version of chef client to use
     type: string
-    default: 11.14.2
+    default: 11.14.6
 
 resources:
 


### PR DESCRIPTION
The `build-essential` cookbook is now a requirement since some of the StrongLoop dependencies now require `make` to be installed.
